### PR TITLE
Fix toTitleCase function

### DIFF
--- a/lib/textCaseManipulation.js
+++ b/lib/textCaseManipulation.js
@@ -46,13 +46,16 @@ function swapCase(string) {
     .join("");
 }
 
-// 👨🏻‍💻 Contribution Station - Write a function that Inverts the case of each character in a string.
+// Inverts the case of each character.
 function invertCase(string) {
-  /*  
-  Input: 'Hello World'
-  Expected Output: 'hELLO wORLD'
-  Write your code here and export
-  */
+  // Input: 'Hello World'
+  // Output: 'hELLO wORLD'
+  return string
+    .split("")
+    .map((char) =>
+      char === char.toUpperCase() ? char.toLowerCase() : char.toUpperCase()
+    )
+    .join("");
 }
 
 // 👨🏻‍💻 Contribution Station - Write a function that converts a string into snake_case

--- a/lib/textCaseManipulation.js
+++ b/lib/textCaseManipulation.js
@@ -30,9 +30,7 @@ function toAlternateCase(string) {
 function toTitleCase(string) {
   // Input: 'hello world from STRING utils'
   // Output: 'Hello World From STRING Utils'
-  return string
-    .toLowerCase()
-    .replace(/(?:^|\s)\w/g, (match) => match.toUpperCase());
+  return string.replace(/\b\w/g, (match) => match.toUpperCase());
 }
 
 function swapCase(string) {


### PR DESCRIPTION
Summary of Pull Request
This pull request addresses a bug related to the ```toTitleCase``` function, which currently changes all the strings to lower case and then the logic of toTitleCase is applied.

Current Behavior
Currently, when we input ```hello world from STRING utils``` the output was ```Hello World From String Utils```.

Proposed New Behavior
The proposed change gives the output as ```Hello World From STRING Utils```. It capitalize only the first letter of each word in the input string while preserving the case of the remaining characters.