### PR TITLE
Add maskPhone function

### DIFF
--- a/lib/textMaskingAndSecurity.js
+++ b/lib/textMaskingAndSecurity.js
@@ -44,13 +44,28 @@ function moderate(text, wordsArray, mask = "*") {
   return moderatedText;
 }
 
-// 📞 Contribution Station - Design a function to mask a phone number.
+// Mask a phone number.
 function maskPhone(phone, visibleDigits = 4) {
-  /*
-    Input: '1234567890'
-    Expected Output: '******7890'
-    Keep the last digits in sight while the rest go incognito. Ready to code? Export function when done.
-  */
+  // Input: '1234567890'
+  // Output: '******7890'
+  const phoneNumber = phone.toString();
+  const phoneNumberLength = phoneNumber.length;
+
+  if (
+    !Number.isInteger(visibleDigits) ||
+    visibleDigits < 0 ||
+    phoneNumberLength !== 10 ||
+    phoneNumber.replace(/\D/g, "").length !== 10
+  ) {
+    throw new Error(
+      "Invalid input. Please provide a non-negative integer for visibleDigits, and ensure it is not greater than the length of the phone number."
+    );
+  }
+
+  const maskedPart = "*".repeat(phoneNumberLength - visibleDigits);
+  const visiblePart = phoneNumber.slice(-visibleDigits);
+
+  return maskedPart + visiblePart;
 }
 
 // 💳 Contribution Station - Compose a function to mask credit card numbers.
@@ -62,4 +77,4 @@ function maskCreditCard(cardNumber, visibleDigits = 4) {
   */
 }
 // Grouped exports
-export { maskEmail, maskCreditCard, maskString, moderate };
+export { maskEmail, maskCreditCard, maskString, moderate, maskPhone };

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -69,3 +69,25 @@ describe("maskEmail", () => {
 
   // More tests for maskEmail...
 });
+
+describe("maskPhone", () => {
+  test("masks phone number with default visibleDigits", () => {
+    const phoneNumber = "1234567890";
+    expect(maskPhone(phoneNumber)).toBe("******7890");
+  });
+
+  test("masks phone number with custom visibleDigits", () => {
+    const phoneNumber = "9876543210";
+    const visibleDigits = 3;
+    expect(maskPhone(phoneNumber, visibleDigits)).toBe("*******210");
+  });
+
+  test("throws error for invalid phone number with special characters", () => {
+    const invalidPhoneNumber = "1-23-45-67-890";
+    expect(() => maskPhone(invalidPhoneNumber)).toThrowError(
+      "Invalid input. Please provide a non-negative integer for visibleDigits, and ensure it is not greater than the length of the phone number."
+    );
+  });
+
+  // Add more test cases as needed...
+});


### PR DESCRIPTION
Pull Request Summary
This pull request introduces a new function, ```maskPhone```, designed to mask a phone number while keeping a specified number of visible digits. The function takes two parameters: phone (the input phone number) and visibleDigits (the number of visible digits to retain, defaulting to 4).

Further, Test cases are added for the same function.

Issue: https://github.com/swanandapps/stringy-core/issues/7

Example:
<img width="500" alt="image" src="https://github.com/swanandapps/stringy-core/assets/22127725/4ed14106-06e7-43b6-8e5b-cdf8be5f2a4c">
